### PR TITLE
fix: support numeric WBI parameters

### DIFF
--- a/src/Service/Processing.php
+++ b/src/Service/Processing.php
@@ -271,7 +271,7 @@ class Processing
         $chrFilter = "/[!'()*]/";
         $query = [];
         foreach ($params as $key => $value) {
-            $value = preg_replace($chrFilter, '', $value);
+            $value = preg_replace($chrFilter, '', (string) $value);
             $query[] = urlencode($key) . '=' . urlencode($value);
         }
         $queryStr = implode('&', $query);


### PR DESCRIPTION
## Summary

- cast WBI parameter values to strings before applying the character filter
- prevent TypeError when APIs provide numeric parameters such as room_id

## Context

Live::getInitialWebSocketUrl() passes an integer room ID through encWbi(). With strict types enabled, preg_replace() rejects that integer subject and crashes the caller before the WebSocket connection can be created.

## Verification

- reproduced the original TypeError on PHP 8.1 with strict types
- ran php -l on Processing.php
- called encWbi() with an integer room_id and a string containing filtered characters; both were encoded correctly