### PR TITLE
fix(core): 增加解压与编码失败的类型安全检查

### DIFF
--- a/src/Service/Processing.php
+++ b/src/Service/Processing.php
@@ -218,6 +218,9 @@ class Processing
             throw new \Exception("未安装 brotli 扩展");
         }
         $decompressedBody = brotli_uncompress($data);
+        if ($decompressedBody === false) {
+            throw new \Exception("brotli 解压失败");
+        }
         $off = 0;
         $max = strlen(substr($decompressedBody, 16));
         $decode = [];
@@ -233,14 +236,17 @@ class Processing
 
     /**
      * zlib 解压
-     * 
+     *
      * @param string $data 正文数据
-     * 
+     *
      * @return array|false []
      */
     public static function zlib(string $data): array|false
     {
-        $decompressedBody = gzuncompress($data);
+        $decompressedBody = @gzuncompress($data);
+        if ($decompressedBody === false) {
+            return false;
+        }
         $off = 0;
         $max = strlen(substr($decompressedBody, 16));
         $decode = [];

--- a/src/WebSocket.php
+++ b/src/WebSocket.php
@@ -39,6 +39,9 @@ class WebSocket
             'type' => 2,
             'key' => $token
         ]);
+        if ($packet === false) {
+            throw new \Exception("认证包 JSON 编码失败: " . json_last_error_msg());
+        }
         // 获取头部
         $buildHeader = Processing::buildHeader(strlen($packet), 1, 7);
         return $buildHeader . $packet;


### PR DESCRIPTION
对 brotli_uncompress、gzuncompress、json_encode 可能返回 false 的函数增加失败检查，避免 PHP 8.0+ 严格类型模式下引发 TypeError。